### PR TITLE
add dynamic scope

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -512,8 +512,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     self.app.get(authPath, function(req, res, next) {
       var func = (link ? passport.authorize : passport.authenticate).bind(passport);
       func(name, _.defaults({
-        state: encodeURIComponent(req._parsedOriginalUrl.search || ''),
-        scope: scope,
+        state: req.query.state || encodeURIComponent(req._parsedOriginalUrl.search || ''),
+        callbackURL: req.query.callback_url || callbackURL,
+        scope: req.query.scope || scope,
         session: session
       }, options.authOptions))(req, res, next);
     });


### PR DESCRIPTION
## why add scope in query

  if provider have two type auth, such as wechat has _snsapi-base_ and _sns-userinfo_. then you have to config two provider in provider.json, and passport will create two instance of UserIndentity, one for sns-base, another one for _sns-userinfo_, it's not what we expect that only create one Indentity for same openid

  dynamic  scope will be useful when one provider have two type auth  and passport can dynamically decide authPath without two provider config

in order to use this scope, i have make another pr https://github.com/weflex/passport-wechat2/pull/1
